### PR TITLE
docs(schedules): mark modular flow as complete

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,14 +31,14 @@
 - Indicador visual de nivel (breadcrumb en AppBar: `Grupos > Grupo > Lanzadera`) _(listo)_
 - Gestión de stack y botón atrás del sistema documentada _(listo)_
 
-**3. Flujo de Horarios y Gestión Modular**
+**3. Flujo de Horarios y Gestión Modular** ✅ _Especificación cerrada en `SPECS.md`_
 - Separar completamente edición de lanzadera vs. horarios:
-  - **Pantalla edición lanzadera**: Solo nombre, origen/destino, comentario general, plazas por defecto (NO horarios)
-  - **Pantalla dedicada horarios**: Crear, editar, eliminar horarios (accesible desde pestaña Horarios en nivel Lanzadera)
-- Especificar flujo de creación: lanzadera sin horarios inicialmente + modal post-creación "¿Agregar primer horario?"
-- Definir pantalla de detalle de salida (hora concreta) con solicitar/anular plaza, rol/conductor visible
-- Implementar chips de Ida/Vuelta + resumen compacto de horarios
-- Aclarar comentario único por lanzadera (no por horario)
+  - **Pantalla edición lanzadera**: Solo nombre, origen/destino, comentario general, plazas por defecto (NO horarios) _(listo)_
+  - **Pantalla dedicada horarios**: Crear, editar, eliminar horarios (accesible desde pestaña Horarios en nivel Lanzadera) _(listo)_
+- Especificar flujo de creación: lanzadera sin horarios inicialmente + modal post-creación "¿Agregar primer horario?" _(listo)_
+- Definir pantalla de detalle de salida (hora concreta) con solicitar/anular plaza, rol/conductor visible _(listo)_
+- Implementar chips de Ida/Vuelta + resumen compacto de horarios _(listo)_
+- Aclarar comentario único por lanzadera (no por horario) _(listo)_
 
 **4. Sistema de Conflictos de Días en Horarios**
 - Especificar validación de solapamiento al seleccionar día ya ocupado:

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -1517,8 +1517,6 @@ De este modo, los horarios creados en un sentido se aplican a todos los días ma
 En la parte superior se mostrarán los lugares de recogida y destino correspondientes a cada vista de Ida o Vuelta, para evitar confusiones. Por ejemplo, si en la vista de ida los horarios indican salidas desde la Estación hacia la Nave, se mostrará arriba: “Salida desde: Estación · Destino: Nave”, y viceversa en la vista de vuelta.
 Además, el color del texto de cada lugar (tanto en “Salida desde” como en “Destino”) coincidirá con el color del sentido del viaje —azul para Ida y rojo para Vuelta— para facilitar su comprensión visual. Cada sentido mantendrá siempre su color asociado, aunque los lugares intercambien su posición como origen o destino según esté seleccionada la vista de Ida o de Vuelta en la sección de horas.
 
-En esta pantalla no se mostrará “Ver comentario”, ya que no es editable y solo aparece en la pantalla 6.1.1 Consulta/Horario.
-
 El guardado de cambios se hará desde el boton de guardar abajo a la derecha en la misma pantalla (tambien estará el de cancelar a la izquierda). Si sale de la pantalla sin pulsar el botón de guardado se abre un modal que pide confirmación para guardar cambios (este estado hay que guardarlo para que esta parte se cumpla aunque se cierre la app).
 
 #### **6.4 Mapa** _(incluido en MVP)_

--- a/docs/dev_log.md
+++ b/docs/dev_log.md
@@ -76,9 +76,9 @@ Fase activa: **1 — Configuración inicial / Arquitectura**
 
 - Se definió la **Pantalla 8 — Mis Solicitudes** en `SPECS.md`, con acceso desde el icono ✋ en Home/Chat/Horarios/Mapa de los 3 niveles y sin icono en pantallas secundarias.
 - Se creó `docs/GLOSSARY.md` y se enlazó desde specs/README; términos CTA/Salida/Badge referenciados.
-- `ROADMAP.md` actualizado: prioridad alta ítem 1 marcado como completado (especificación cerrada).
 - Se completó la especificación de **Navegación y Menús Superiores Contextuales** (breadcrumb, stack PageView por nivel, menús ⋮ por pantalla, botón atrás del sistema, transiciones).
-- `ROADMAP.md` actualizado: prioridad alta ítem 2 marcado como completado (especificación cerrada).
+- Se cerró el **Flujo de Horarios y Gestión Modular**: separación edición lanzadera vs. horarios, flujo de creación sin horarios + modal, detalle de salida (solicitar/anular), chips Ida/Vuelta y comentario único por lanzadera.
+- `ROADMAP.md` actualizado: prioridad alta ítem 3 marcado como completado (especificación cerrada).
 
 ### 🧠 Decisiones tomadas:
 


### PR DESCRIPTION
Update roadmap and dev log to reflect completed shuttle schedule flow: creation modal, separate editing, trip detail actions, ida/vuelta chips, and single shuttle comment.