### PR TITLE
docs(specs-schedules): finalize day conflict handling

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,12 +18,14 @@
 #### 🔴 Prioridad Alta (Crítico para MVP)
 
 **1. Pantalla 8 — Estado de Mis Solicitudes** ✅ _Especificación completada en `SPECS.md` (acceso ✋ y vistas viajero/conductor)_
+
 - Completar especificación detallada de P8 con vista completa para **viajero** y **conductor** _(listo)_
 - Definir interfaz de usuario: layout de lista (futuras vs. pasadas), diseño de cada ítem, acciones disponibles _(listo)_
 - Documentar todos los estados: Pendiente de conductor, Confirmada, En curso, Completada, Cancelada (por usuario/falta conductor/administrador) _(listo)_
 - Aclarar si es pantalla independiente o modal dentro de 6.1 _(listo: pantalla independiente con acceso desde icono ✋)_
 
 **2. Navegación y Menús Superiores Contextuales** ✅ _Especificación cerrada en `SPECS.md`_
+
 - Definir **stack/nested navigation** completo (Grupos → Grupo → Lanzadera con PageView) _(listo)_
 - Especificar menús contextuales (⋮) por tipo de pantalla (Home/Chat/Horarios/Mapa) en cada nivel _(listo)_
 - Cambio de nivel solo desde Home/ítems + flecha atrás, manteniendo pestaña activa del PageView _(listo)_
@@ -32,6 +34,7 @@
 - Gestión de stack y botón atrás del sistema documentada _(listo)_
 
 **3. Flujo de Horarios y Gestión Modular** ✅ _Especificación cerrada en `SPECS.md`_
+
 - Separar completamente edición de lanzadera vs. horarios:
   - **Pantalla edición lanzadera**: Solo nombre, origen/destino, comentario general, plazas por defecto (NO horarios) _(listo)_
   - **Pantalla dedicada horarios**: Crear, editar, eliminar horarios (accesible desde pestaña Horarios en nivel Lanzadera) _(listo)_
@@ -40,14 +43,14 @@
 - Implementar chips de Ida/Vuelta + resumen compacto de horarios _(listo)_
 - Aclarar comentario único por lanzadera (no por horario) _(listo)_
 
-**4. Sistema de Conflictos de Días en Horarios**
-- Especificar validación de solapamiento al seleccionar día ya ocupado:
-  - Mostrar días ocupados en gris
-  - Modal de confirmación: [Cancelar] [Confirmar fusión]
-- Definir modal de advertencia al deseleccionar días con confirmación explícita
-- Documentar interfaz visual: días disponibles (azul/rojo), días ocupados (gris), días en edición (resaltado)
+**4. Sistema de Conflictos de Días en Horarios** ✅ _Especificación cerrada en `SPECS.md`_
+
+- Validación de solapamiento al seleccionar día ocupado: días ocupados visibles en gris; modal con opciones [Cancelar]/[Ver horas actuales] + tarjetas (horas actuales / fusionar / nuevas) y confirmación.
+- Modal al deseleccionar día con confirmación explícita (eliminar horas / cancelar).
+- Interfaz visual documentada: días disponibles (blanco/borde gris), seleccionados (azul/rojo), ocupados (gris).
 
 **5. Chats Privados entre Usuarios**
+
 - Definir punto de acceso exacto: ¿icono específico/menú contextual/botón en perfil?
 - Resolver conflicto: pulsar avatar/nombre abre perfil → especificar acceso alternativo a chat privado
 - Documentar lista de chats privados activos: ubicación, organización, indicadores de no leídos
@@ -56,12 +59,14 @@
 #### 🟡 Prioridad Media (Post-MVP)
 
 **6. Centro de Notificaciones (6.2)**
+
 - Especificar pantalla completa: acceso desde menú principal, diseño de lista, categorización, filtros
 - Definir tipos de notificaciones y acciones asociadas:
   - Nuevas lanzaderas, solicitudes aprobadas, conductor asignado, cambios en horarios, invitaciones, mensajes chat, alertas conductor sin ubicación
 - Documentar gestión: marcar leída, archivar, eliminar, marcar todas como leídas
 
 **7. Terminología y Contenido por Nivel**
+
 - Unificar terminología: "**Frecuencia semanal**" vs. "**Fecha única**" en todo el documento
 - Definir etiqueta dinámica del campo fecha (cambia según selección de días)
 - Especificar comportamiento DatePicker en modo frecuencia
@@ -71,11 +76,13 @@
   - **Mapa**: Grupos (elegir grupo), Grupo (lista mapas), Lanzadera (mapa + posición/flecha)
 
 **8. Historial de Reputación**
+
 - Definir cálculo: fórmula (viajes solicitados vs. realizados), escala 1-5
 - Documentar factores que afectan: cancelaciones (viajero/conductor), viajes completados, puntualidad, reportes
 - Especificar visibilidad: perfil público (puntuación), perfil privado (desglose), lista viajeros (indicador rápido)
 
 **9. Otras Funcionalidades**
+
 - **Conductor visible en listado**: Mostrar "Conductor: Nombre" o "Sin conductor" en ítems de 5.3
 - **Rol predeterminado**: Checkbox en selección de rol + opción en ajustes de lanzadera para cambiar; rol visible en UI
 - **Gestión de vehículos**: Enlace explícito desde ajustes de grupo (5.5)
@@ -85,6 +92,7 @@
 #### 🟢 Prioridad Baja (Versiones Futuras - Documentar para Roadmap)
 
 **10. Backlog Futuro**
+
 - OCR para horarios: agregar lanzadera desde imagen con sugerencia IA
 - Crear `CHANGELOG.md` en raíz del proyecto con formato estándar
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -1481,12 +1481,18 @@ En esta pantalla será posible:
 1. Seleccionar los días semanales, pudiendo agregar o quitar días en este horario, **siempre que no estén ya usados por otro horario de la lanzadera**.
    En caso de intentar añadir un día que ya tenga un horario asignado, se abrirá un **modal informativo** indicando que no es posible añadirlo porque ya está ocupado, ofreciendo las siguientes opciones:
 
-   - **Fusionar ambos días**.
-   - **Establecer nuevas horas** para ese día (lo que eliminará las horas previamente configuradas en él).
-   - **Cancelar la elección de día**.
-   - **Ver las horas actuales de ese día** para comparar y decidir.
+   - **[Cancelar]**
+   - **[Ver horas actuales]**
 
-   Si el usuario sale del modal pulsando **Cancelar** (o cualquier otra acción que implique cancelación de la selección), el día que acababa de seleccionar quedará **deseleccionado automáticamente**.
+   Si se pulsa **Ver horas actuales**, se muestran **tres tarjetas comparativas** con el resultado final de las horas para ese día, para elegir **una sola opción**:
+
+   - **Horas actuales**: mantiene exactamente las horas que ya tiene el día.
+   - **Fusionar horas**: mezcla horas actuales + nuevas sin duplicados (mostrar lista resultante).
+   - **Horas nuevas**: sustituye las horas actuales por las nuevas seleccionadas.
+
+   Tras elegir una tarjeta:  
+   - aparece un botón **[Confirmar]** para aplicar la opción. 
+   - Si el usuario sale del modal pulsando **Cancelar** (o cualquier otra acción que implique cancelación de la selección), el día que acababa de seleccionar quedará **deseleccionado automáticamente**.
 
    En caso de deseleccionar un día que ya formaba parte del horario, se abrirá un modal de confirmación preguntando qué acción realizar.  
    Este modal mostrará las siguientes opciones:
@@ -1518,6 +1524,14 @@ En la parte superior se mostrarán los lugares de recogida y destino correspondi
 Además, el color del texto de cada lugar (tanto en “Salida desde” como en “Destino”) coincidirá con el color del sentido del viaje —azul para Ida y rojo para Vuelta— para facilitar su comprensión visual. Cada sentido mantendrá siempre su color asociado, aunque los lugares intercambien su posición como origen o destino según esté seleccionada la vista de Ida o de Vuelta en la sección de horas.
 
 El guardado de cambios se hará desde el boton de guardar abajo a la derecha en la misma pantalla (tambien estará el de cancelar a la izquierda). Si sale de la pantalla sin pulsar el botón de guardado se abre un modal que pide confirmación para guardar cambios (este estado hay que guardarlo para que esta parte se cumpla aunque se cierre la app).
+
+**Estados visuales de días (selector semanal en 6.3.3):**
+
+- **Disponible (no seleccionado):** fondo blanco, borde gris claro.
+- **Seleccionado (horario actual):** fondo azul (Ida) o rojo (Vuelta), texto blanco.
+- **Ocupado por otro horario:** fondo gris medio (#BDBDBD), texto gris oscuro; se ve así al cargar la pantalla. Solo abre el modal al pulsar.
+
+**Leyenda/ayuda breve:** “Gris = ocupado por otro horario; Azul/Rojo = seleccionado; Blanco = disponible.”
 
 #### **6.4 Mapa** _(incluido en MVP)_
 

--- a/docs/dev_log.md
+++ b/docs/dev_log.md
@@ -78,7 +78,8 @@ Fase activa: **1 — Configuración inicial / Arquitectura**
 - Se creó `docs/GLOSSARY.md` y se enlazó desde specs/README; términos CTA/Salida/Badge referenciados.
 - Se completó la especificación de **Navegación y Menús Superiores Contextuales** (breadcrumb, stack PageView por nivel, menús ⋮ por pantalla, botón atrás del sistema, transiciones).
 - Se cerró el **Flujo de Horarios y Gestión Modular**: separación edición lanzadera vs. horarios, flujo de creación sin horarios + modal, detalle de salida (solicitar/anular), chips Ida/Vuelta y comentario único por lanzadera.
-- `ROADMAP.md` actualizado: prioridad alta ítem 3 marcado como completado (especificación cerrada).
+- Se cerró el **Sistema de Conflictos de Días en Horarios**: días ocupados visibles en gris, modal con tarjetas comparativas (horas actuales/fusionar/nuevas) y confirmación, y guía visual de estados de día.
+- `ROADMAP.md` actualizado: prioridad alta ítem 4 marcado como completado (especificación cerrada).
 
 ### 🧠 Decisiones tomadas:
 


### PR DESCRIPTION
Mark roadmap/dev log for completed day conflict spec; add modal flow with comparative options and day state visuals (available, selected, occupied).